### PR TITLE
GFX/MAKEFILE: Remove unused target rap.exe (from Raptor sources)

### DIFF
--- a/GFX/MAKEFILE
+++ b/GFX/MAKEFILE
@@ -40,10 +40,6 @@ gfx.lib : $(objs)
 	 %make temp.lnk
 	 wlib $^@ /n /b @temp.lnk
 
-rap.exe : $(objs)
-	 %make temp.lnk
-	 wlink @temp.lnk
-
 # implicit rules
 
 temp.lnk : objdef.mif makefile


### PR DESCRIPTION
It was originally introduced while using Raptor's makefile as a base.

I've still managed to build GFX.LIB and RAP.EXE files as usual. Game is playable, at least in a subset of Bravo Sector's wave 1.